### PR TITLE
Single threaded client emulating several clients

### DIFF
--- a/src/test/java/org/imdea/vcd/Client.java
+++ b/src/test/java/org/imdea/vcd/Client.java
@@ -2,11 +2,10 @@ package org.imdea.vcd;
 
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.imdea.vcd.pb.Proto.Message;
 import org.imdea.vcd.pb.Proto.MessageSet;
 import redis.clients.jedis.Jedis;
@@ -17,117 +16,140 @@ import redis.clients.jedis.Jedis;
  */
 public class Client {
 
+    private static Metrics METRICS;
+    private static Config CONFIG;
+    private static Socket SOCKET;
+    private static Map<ByteString, PerData> MAP;
+    private static int[] OPS_PER_CLIENT;
+    private static int CLIENTS_DONE;
+
     public static void main(String[] args) {
         try {
-            Config config = Config.parseArgs(args);
-            Integer clients = config.getClients();
-            ClientRunner runners[] = new ClientRunner[clients];
+            METRICS = new Metrics();
+            CONFIG = Config.parseArgs(args);
+            SOCKET = Socket.create(CONFIG);
+            MAP = new HashMap<>();
+            OPS_PER_CLIENT = new int[CONFIG.getClients()];
+            CLIENTS_DONE = 0;
 
-            for (int i = 0; i < clients; i++) {
-                ClientRunner runner = new ClientRunner(config);
-                runners[i] = runner;
-            }
+            System.out.println("Connect OK!");
+            start();
 
-            for (int i = 0; i < clients; i++) {
-                runners[i].start();
-            }
-
-            for (int i = 0; i < clients; i++) {
-                runners[i].join();
-            }
-        } catch (Exception e) {
-            e.printStackTrace(System.err);
-        }
-    }
-
-    public static void println(String s) {
-        synchronized (System.out) {
-            System.out.println(s);
-        }
-    }
-
-    private static class ClientRunner extends Thread {
-
-        private final Config config;
-        private final Metrics metrics;
-
-        public ClientRunner(Config config) {
-            this.config = config;
-            this.metrics = new Metrics();
-        }
-
-        @Override
-        public void run() {
-            try {
-                Socket socket = Socket.create(config);
-
-                println("Connect OK!");
-
-                Thread.sleep(2000);
-
-                for (int i = 1; i <= config.getOps(); i++) {
-                    if (i % 100 == 0) {
-                        println(i + " of " + config.getOps());
-                    }
-                    MessageSet messageSet = RandomMessageSet.generate(config);
-                    ByteString id = messageSet.getMessagesList().get(0).getData();
-                    Long start = this.metrics.start();
-                    socket.send(messageSet);
-                    receiveMessage(start, id, socket);
-                }
-
-                println(this.metrics.show());
-
-                push();
-            } catch (IOException | InterruptedException ex) {
-                Logger.getLogger(Client.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-
-        private void receiveMessage(Long start, ByteString id, Socket socket) throws IOException {
-            boolean found = false;
-            while (!found) {
-                MessageSet messageSet = socket.receive();
+            while (CLIENTS_DONE != CONFIG.getClients()) {
+                MessageSet messageSet = SOCKET.receive();
                 List<Message> messages = messageSet.getMessagesList();
                 MessageSet.Status status = messageSet.getStatus();
 
                 // record chain size
-                this.metrics.chain(messages.size());
+                METRICS.chain(messages.size());
 
+                ByteString data;
+                PerData perData;
                 switch (status) {
                     case COMMITTED:
-                        this.metrics.end(status, start);
+                        data = messages.get(0).getData();
+                        perData = MAP.get(data);
+                        // record commit time
+                        METRICS.end(status, perData.getStartTime());
                         // keep waiting
                         break;
                     case DELIVERED:
                         Iterator<Message> it = messages.iterator();
 
-                        // try to find the message I just sent
-                        while (it.hasNext() && !found) {
-                            found = it.next().getData().equals(id);
-                        }
+                        // try to find operations from clients
+                        while (it.hasNext()) {
+                            data = it.next().getData();
+                            perData = MAP.get(data);
 
-                        // if found, the cycle breaks
-                        // otherwise, keep waiting
-                        if (found) {
-                            this.metrics.end(status, start);
+                            // if it belongs to a client
+                            if (perData != null) {
+                                int client = perData.getClient();
+                                Long startTime = perData.getStartTime();
+
+                                // record delivery time
+                                METRICS.end(status, startTime);
+                                // increment number of ops of this client
+                                OPS_PER_CLIENT[client]++;
+
+                                // log every 100 ops
+                                if (OPS_PER_CLIENT[client] % 100 == 0) {
+                                    System.out.println(OPS_PER_CLIENT[client] + " of " + CONFIG.getOps());
+                                }
+
+                                if (OPS_PER_CLIENT[client] == CONFIG.getOps()) {
+                                    // if it performed all the operations
+                                    // increment number of clients done
+                                    CLIENTS_DONE++;
+                                } else {
+                                    // otherwise send another operation
+                                    sendOp(client);
+                                }
+                            }
                         }
                         break;
                 }
             }
+
+            // after all operations from all clients
+            // show metrics
+            System.out.println(METRICS.show());
+            
+            // and push them to redis
+            redisPush();
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
         }
+    }
 
-        private void push() {
-            String redis = this.config.getRedis();
+    private static void start() throws IOException {
+        for (int i = 0; i < CONFIG.getClients(); i++) {
+            sendOp(i);
+        }
+    }
 
-            if (redis != null) {
-                try (Jedis jedis = new Jedis(redis)) {
-                    Map<String, String> push = this.metrics.serialize(config);
-                    for (String key : push.keySet()) {
-                        jedis.sadd(key, push.get(key));
-                    }
+    private static void sendOp(int client) throws IOException {
+        MessageSet messageSet = RandomMessageSet.generate(CONFIG);
+        ByteString data = messageSet.getMessagesList().get(0).getData();
+        if (MAP.containsKey(data)) {
+            // if this key already exists, try again
+            sendOp(client);
+        } else {
+            // if it doesn't, send it and update map
+            PerData perData = new PerData(client, METRICS.start());
+            MAP.put(data, perData);
+            SOCKET.send(messageSet);
+        }
+    }
+
+    private static void redisPush() {
+        String redis = CONFIG.getRedis();
+
+        if (redis != null) {
+            try (Jedis jedis = new Jedis(redis)) {
+                Map<String, String> push = METRICS.serialize(CONFIG);
+                for (String key : push.keySet()) {
+                    jedis.sadd(key, push.get(key));
                 }
             }
+        }
+    }
+
+    private static class PerData {
+
+        private final int client;
+        private final Long startTime;
+
+        public PerData(int client, Long startTime) {
+            this.client = client;
+            this.startTime = startTime;
+        }
+
+        public int getClient() {
+            return client;
+        }
+
+        public long getStartTime() {
+            return startTime;
         }
     }
 }

--- a/src/test/java/org/imdea/vcd/Client.java
+++ b/src/test/java/org/imdea/vcd/Client.java
@@ -65,6 +65,9 @@ public class Client {
                             if (perData != null) {
                                 int client = perData.getClient();
                                 Long startTime = perData.getStartTime();
+                                
+                                // delete from the map
+                                MAP.remove(data);
 
                                 // record delivery time
                                 METRICS.end(status, startTime);

--- a/src/test/java/org/imdea/vcd/Metrics.java
+++ b/src/test/java/org/imdea/vcd/Metrics.java
@@ -1,7 +1,7 @@
 package org.imdea.vcd;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.imdea.vcd.pb.Proto.MessageSet;
@@ -17,9 +17,9 @@ public class Metrics {
     private final List<Long> DELIVERED_TIMES;
 
     public Metrics() {
-        this.CHAIN_LENGTHS = new ArrayList<>();
-        this.COMMITTED_TIMES = new ArrayList<>();
-        this.DELIVERED_TIMES = new ArrayList<>();
+        this.CHAIN_LENGTHS = new LinkedList<>();
+        this.COMMITTED_TIMES = new LinkedList<>();
+        this.DELIVERED_TIMES = new LinkedList<>();
     }
 
     public void chain(Integer size) {


### PR DESCRIPTION
Local micro-benchmark:
- single server node
- 100k ops per client
- results (in microseconds) show average delivery time
- always `chains = 1`, and thus, other measurements needed

Before:
- 3 clients: 203
- 6 clients: 551
- 12 clients: 1248

After:
- 3 clients: 147
- 6 clients: 243
- 12 clients: 455
- 24 clients: 912
- 48 clients: 1903