### PR TITLE
On Socket.close(), stop spawned threads

### DIFF
--- a/src/main/java/org/imdea/vcd/Socket.java
+++ b/src/main/java/org/imdea/vcd/Socket.java
@@ -108,7 +108,7 @@ public class Socket {
         return this.rw.read();
     }
 
-    public void closeRw() throws IOException {
+    public void close() throws IOException {
         this.rw.close();
     }
 

--- a/src/test/java/org/imdea/vcd/Client.java
+++ b/src/test/java/org/imdea/vcd/Client.java
@@ -125,6 +125,8 @@ public class Client {
 
             // and push them to redis
             redisPush();
+
+            SOCKET.close();
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.toString(), e);
         }


### PR DESCRIPTION
On `Socket.close()` we get:

```bash
[2018-05-01 15:30:40] [SEVERE ] java.lang.InterruptedException
[2018-05-01 15:30:40] [SEVERE ] java.net.SocketException: Socket closed
```