### PR TITLE
Open loop client

### DIFF
--- a/src/main/java/org/imdea/vcd/Config.java
+++ b/src/main/java/org/imdea/vcd/Config.java
@@ -13,6 +13,8 @@ import org.imdea.vcd.queue.QueueType;
 @Parameters(separators = "=") // http://jcommander.org/#_parameter_separators
 public class Config {
 
+    private static final int CLOSED_LOOP = 42;
+
     @Parameter(names = "-batch_wait")
     private Integer batchWait = 0; // if 0, batching is disabled
 
@@ -51,6 +53,9 @@ public class Config {
 
     @Parameter(names = "-queue_type", description = "which queue to use; possible values: dep, conf, random")
     private QueueType queueType = QueueType.DEP;
+
+    @Parameter(names = "-sleep", description = "sleep time between ops for open loop clients; set this to 42 for close loop client behaviour")
+    private Integer sleep = CLOSED_LOOP;
 
     private Config() {
     }
@@ -157,6 +162,18 @@ public class Config {
 
     public void setQueueType(QueueType queueType) {
         this.queueType = queueType;
+    }
+
+    public Integer getSleep() {
+        return sleep;
+    }
+
+    public void setSleep(Integer sleep) {
+        this.sleep = sleep;
+    }
+
+    public boolean getClosedLoop() {
+        return this.sleep == CLOSED_LOOP;
     }
 
     public static Config parseArgs(String[] args) {

--- a/src/test/java/org/imdea/vcd/Client.java
+++ b/src/test/java/org/imdea/vcd/Client.java
@@ -2,10 +2,12 @@ package org.imdea.vcd;
 
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.imdea.vcd.pb.Proto.Message;
@@ -19,149 +21,328 @@ import redis.clients.jedis.Jedis;
 public class Client {
 
     private static final Logger LOGGER = VCDLogger.init(Client.class);
-
     private static final int CONNECT_RETRIES = 100;
-
-    private static Metrics METRICS;
-    private static Config CONFIG;
-    private static Socket SOCKET;
-    private static Map<ByteString, PerData> MAP;
-    private static int[] OPS_PER_CLIENT;
-    private static int CLIENTS_DONE;
 
     public static void main(String[] args) {
         try {
-            METRICS = new Metrics();
-            CONFIG = Config.parseArgs(args);
-            SOCKET = Socket.create(CONFIG, CONNECT_RETRIES);
-            MAP = new HashMap<>();
-            OPS_PER_CLIENT = new int[CONFIG.getClients()];
-            CLIENTS_DONE = 0;
-
-            LOGGER.log(Level.INFO, "Connect OK!");
-
-            start();
-
-            while (CLIENTS_DONE != CONFIG.getClients()) {
-                try {
-                    MessageSet messageSet = SOCKET.receive();
-                    List<Message> messages = messageSet.getMessagesList();
-                    MessageSet.Status status = messageSet.getStatus();
-
-                    ByteString data;
-                    PerData perData;
-                    switch (status) {
-                        case DURABLE:
-                            data = messages.get(0).getData();
-                            perData = MAP.get(data);
-                            // record commit time, if perData exists
-                            // TODO check how to could have been delivered
-                            // before being committed
-                            // - maybe collision with another message,
-                            //   in another node
-                            // - or on recovery?
-                            if (perData != null) {
-                                METRICS.end(status, perData.getStartTime());
-                            }
-                            // keep waiting
-                            break;
-                        case DELIVERED:
-                            // record chain size
-                            METRICS.chain(messages.size());
-
-                            Iterator<Message> it = messages.iterator();
-
-                            // try to find operations from clients
-                            while (it.hasNext()) {
-                                data = it.next().getData();
-                                perData = MAP.remove(data);
-
-                                // if it belongs to a client
-                                if (perData != null) {
-                                    int client = perData.getClient();
-                                    Long startTime = perData.getStartTime();
-
-                                    // record delivery time
-                                    METRICS.end(status, startTime);
-                                    // increment number of ops of this client
-                                    OPS_PER_CLIENT[client]++;
-
-                                    // log every 100 ops
-                                    if (OPS_PER_CLIENT[client] % 100 == 0) {
-                                        LOGGER.log(Level.INFO, "{0} of {1}",
-                                                new String[]{String.valueOf(OPS_PER_CLIENT[client]), String.valueOf(CONFIG.getOps())});
-                                    }
-
-                                    if (OPS_PER_CLIENT[client] == CONFIG.getOps()) {
-                                        // if it performed all the operations
-                                        // increment number of clients done
-                                        CLIENTS_DONE++;
-                                    } else {
-                                        // otherwise send another operation
-                                        sendOp(client);
-                                    }
-                                }
-                            }
-                            break;
-                    }
-                } catch (IOException e) {
-                    // close current socket
-                    SOCKET.close();
-                    // if at any point the socket errors inside this loop,
-                    // reconnect to the closest server
-                    SOCKET = Socket.create(CONFIG, CONNECT_RETRIES);
-                    // clear current map
-                    MAP = new HashMap<>();
-                    // and send a new op per client
-                    start();
-                }
-
-            }
-
-            // after all operations from all clients
-            // show metrics
-            LOGGER.log(Level.INFO, METRICS.show());
-
-            // and push them to redis
-            redisPush();
-
-            SOCKET.close();
-        } catch (Exception e) {
+            Config config = Config.parseArgs(args);
+            ClientWriter writer = new ClientWriter(config);
+            writer.start();
+            writer.join();
+        } catch (InterruptedException e) {
             LOGGER.log(Level.SEVERE, e.toString(), e);
         }
     }
 
-    private static void start() throws IOException, InterruptedException {
-        for (int i = 0; i < CONFIG.getClients(); i++) {
-            sendOp(i);
+    private static class ClientWriter extends Thread {
+
+        private int id = 0;
+
+        private final Config config;
+        private final Metrics metrics;
+        private final int[] opsPerClient;
+        private final Semaphore done;
+
+        private ConcurrentHashMap<ByteString, PerData> opToData;
+        private LinkedBlockingQueue<Integer> toWriter;
+        private Socket socket;
+        private int clientsDone;
+        private ClientReader reader;
+
+        public ClientWriter(Config config) {
+            this.config = config;
+            this.metrics = new Metrics();
+            this.opsPerClient = new int[this.config.getClients()];
+            this.done = new Semaphore(0);
         }
-    }
 
-    private static void sendOp(int client) throws IOException, InterruptedException {
-        MessageSet messageSet = Generator.messageSet(CONFIG);
-        ByteString data = messageSet.getMessagesList().get(0).getData();
-        if (MAP.containsKey(data)) {
-            // if this key already exists, try again
-            sendOp(client);
-        } else {
-            // if it doesn't, send it and update map
-            PerData perData = new PerData(client, METRICS.start());
-            MAP.put(data, perData);
-            SOCKET.send(messageSet);
+        @Override
+        public void run() {
+            try {
+                this.init(false);
+                LOGGER.log(Level.INFO, "Connect OK!");
+
+                // start write loop
+                this.writeLoop();
+
+                // after all operations from all clients
+                // show metrics
+                this.done.acquire();
+                LOGGER.log(Level.INFO, this.metrics.show());
+
+                // and push them to redis
+                this.redisPush();
+
+                this.socket.close();
+
+            } catch (IOException | InterruptedException e) {
+                LOGGER.log(Level.SEVERE, e.toString(), e);
+            }
         }
-    }
 
-    private static void redisPush() {
-        String redis = CONFIG.getRedis();
+        /**
+         * Connect to closest server and start reader thread.
+         */
+        private void init(boolean sendOps) throws IOException, InterruptedException {
+            this.id++;
+            if (this.reader != null) {
+                this.reader.close();
+                this.reader.interrupt();
+            }
+            // make all clients start from the same operation number
+            // (the smallest one)
+            int minOp = Integer.MAX_VALUE;
+            for (int client = 0; client < this.config.getClients(); client++) {
+                minOp = Math.min(minOp, this.opsPerClient[client]);
+            }
+            for (int client = 0; client < this.config.getClients(); client++) {
+                this.opsPerClient[client] = minOp;
+            }
+            this.opToData = new ConcurrentHashMap<>();
+            this.toWriter = new LinkedBlockingQueue<>();
+            this.socket = Socket.create(this.config, CONNECT_RETRIES);
+            this.clientsDone = 0;
+            this.reader = new ClientReader(this.id, this.config, this.socket, this.metrics, this.opToData, this.done, this.toWriter);
+            reader.start();
 
-        if (redis != null) {
-            try (Jedis jedis = new Jedis(redis)) {
-                Map<String, String> push = METRICS.serialize(CONFIG);
-                for (String key : push.keySet()) {
-                    jedis.sadd(key, push.get(key));
+            // maybe send an op per client
+            if (sendOps) {
+                this.nextOps();
+            }
+        }
+
+        private void writeLoop() throws IOException, InterruptedException {
+            // start all clients
+            this.nextOps();
+
+            while (this.clientsDone != this.config.getClients()) {
+                try {
+                    if (this.config.getClosedLoop()) {
+                        int client = this.toWriter.take();
+
+                        if (client == -1) {
+                            // there was an error reading from the socket
+                            this.init(true);
+                        } else {
+                            this.nextOp(client);
+                        }
+                    } else {
+                        int[] sleeps = Generator.ranges(this.config.getSleep(), this.config.getClients());
+                        this.nextOps(sleeps);
+                    }
+                } catch (IOException e) {
+                    LOGGER.log(Level.SEVERE, e.toString(), e);
+                    // if at any point the socket errors inside this loop,
+                    // reconnect to the closest server
+                    // and start reader thread
+                    this.init(true);
                 }
             }
         }
+
+        private void nextOps() throws IOException, InterruptedException {
+            int[] sleeps = new int[this.config.getClients()];
+            nextOps(sleeps);
+        }
+
+        private void nextOps(int[] sleeps) throws IOException, InterruptedException {
+            for (int client = 0; client < this.config.getClients(); client++) {
+                int sleep = sleeps[client];
+                if (sleep > 0) {
+                    Thread.sleep(sleep);
+                }
+                this.nextOp(client);
+            }
+        }
+
+        private void nextOp(int client) throws IOException, InterruptedException {
+            this.opsPerClient[client]++;
+
+            if (this.opsPerClient[client] % 100 == 0) {
+                LOGGER.log(Level.INFO, "({0}) {1} of {2}", new String[]{
+                    String.valueOf(client),
+                    String.valueOf(opsPerClient[client]),
+                    String.valueOf(this.config.getOps())
+                });
+            }
+
+            // generate data
+            ByteString data;
+
+            if (this.opsPerClient[client] < this.config.getOps()) {
+                // normal op
+                do {
+                    data = Generator.messageSetData(this.config);
+                } while (this.opToData.containsKey(data));
+
+            } else if (this.opsPerClient[client] == this.config.getOps()) {
+                // last op
+                data = getLastOp(this.config, client);
+                this.clientsDone++;
+
+            } else {
+                // client is done
+                return;
+            }
+
+            this.sendOp(client, data);
+        }
+
+        private void sendOp(int client, ByteString data) throws IOException, InterruptedException {
+            MessageSet messageSet = Generator.messageSet(this.config.getConflicts(), data);
+            PerData perData = new PerData(client, this.metrics.start());
+            this.opToData.put(data, perData);
+            this.socket.send(messageSet);
+        }
+
+        private void redisPush() {
+            String redis = this.config.getRedis();
+            if (redis != null) {
+                try (Jedis jedis = new Jedis(redis)) {
+                    Map<String, String> push = this.metrics.serialize(this.config);
+                    for (String key : push.keySet()) {
+                        jedis.sadd(key, push.get(key));
+                    }
+                }
+            }
+        }
+
+    }
+
+    private static class ClientReader extends Thread {
+
+        private final int id;
+        // shared with writer thread
+        private final Config config;
+        private final Socket socket;
+        private final Metrics metrics;
+        private final ConcurrentHashMap<ByteString, PerData> opToData;
+        private final Semaphore done;
+        private final LinkedBlockingQueue<Integer> toWriter;
+
+        // local
+        private int clientsDone;
+
+        /**
+         * Since we're only releasing the done semaphore once we see the last op
+         * from all clients, this implementation assumes that by the time this
+         * thread is created, no last op from any client was delivered.
+         */
+        public ClientReader(int id, Config config, Socket socket, Metrics metrics, ConcurrentHashMap<ByteString, PerData> ops, Semaphore done, LinkedBlockingQueue<Integer> toWriter) {
+            this.id = id;
+            this.config = config;
+            this.socket = socket;
+            this.metrics = metrics;
+            this.opToData = ops;
+            this.done = done;
+            this.toWriter = toWriter;
+            this.clientsDone = 0;
+        }
+
+        public void close() throws IOException {
+            this.socket.close();
+        }
+
+        @Override
+        public void run() {
+            try {
+                try {
+                    while (true) {
+                        MessageSet messageSet = this.socket.receive();
+                        List<Message> messages = messageSet.getMessagesList();
+                        MessageSet.Status status = messageSet.getStatus();
+
+                        ByteString data;
+                        PerData perData;
+                        switch (status) {
+                            case DURABLE:
+                                data = messages.get(0).getData();
+                                perData = this.opToData.get(data);
+                                // record commit time, if perData exists
+                                if (perData != null) {
+                                    this.metrics.end(status, perData.getStartTime());
+                                }
+                                // keep waiting
+                                break;
+                            case DELIVERED:
+                                // record chain size
+                                this.metrics.chain(messages.size());
+
+                                Iterator<Message> it = messages.iterator();
+
+                                // try to find operations from clients
+                                while (it.hasNext()) {
+                                    data = it.next().getData();
+                                    perData = this.opToData.remove(data);
+
+                                    // if it belongs to a client
+                                    if (perData != null) {
+                                        int client = perData.getClient();
+                                        Long startTime = perData.getStartTime();
+
+                                        // record delivery time
+                                        this.metrics.end(status, startTime);
+
+                                        // notify writer thread
+                                        this.maybeNotifyOp(client);
+
+                                        // if last op, notify writer thread, and exit
+                                        if (this.maybeNotifyLastOp(client, data)) {
+                                            return;
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+                    }
+                } catch (IOException e) {
+                    LOGGER.log(Level.SEVERE, e.toString(), e);
+                    this.maybeNotifyOp(-1);
+                }
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.SEVERE, e.toString(), e);
+            }
+        }
+
+        /**
+         * If close loop, notify writer thread of which client just delivered an
+         * operation.
+         */
+        private void maybeNotifyOp(int client) throws InterruptedException {
+            if (this.config.getClosedLoop()) {
+                this.toWriter.put(client);
+            }
+        }
+
+        /**
+         * Check if it was the last operation from this client, and if all
+         * clients are done, notify the writer thread by releasing the done
+         * semaphore.
+         */
+        private boolean maybeNotifyLastOp(int client, ByteString data) throws InterruptedException {
+            if (isLastOp(this.config, client, data)) {
+                this.clientsDone++;
+            }
+
+            boolean allClientsAreDone = this.clientsDone == this.config.getClients();
+            if (allClientsAreDone) {
+                this.done.release();
+            }
+            return allClientsAreDone;
+        }
+    }
+
+    private static ByteString getLastOp(Config config, int client) {
+        ByteString data = ByteString.copyFromUtf8(lastOp(config, client));
+        return data;
+    }
+
+    private static boolean isLastOp(Config config, int client, ByteString data) {
+        return data.toStringUtf8().equals(lastOp(config, client));
+    }
+
+    private static String lastOp(Config config, int client) {
+        return config.getCluster() + "-last-op-" + client;
     }
 
     private static class PerData {

--- a/src/test/java/org/imdea/vcd/Generator.java
+++ b/src/test/java/org/imdea/vcd/Generator.java
@@ -20,10 +20,6 @@ import org.imdea.vcd.queue.clock.MaxInt;
 public class Generator {
 
     private static final Integer KEY_SIZE = 8;
-    private static final Integer MIN_ASCII = 33;
-    private static final Integer MAX_ASCII = 126;
-    private static final byte[] CHARACTERS = chars(MIN_ASCII, MAX_ASCII);
-
     private static final ByteString BLACK = repeat((byte) 1, 1);
 
     public static Message message() {
@@ -145,31 +141,21 @@ public class Generator {
         return hash;
     }
 
-    private static ByteString repeat(byte b, Integer payloadSize) {
-        byte[] ba = new byte[payloadSize];
-        for (int i = 0; i < payloadSize; i++) {
+    private static ByteString repeat(byte b, Integer size) {
+        byte[] ba = new byte[size];
+        for (int i = 0; i < size; i++) {
             ba[i] = b;
         }
         return bs(ba);
     }
 
-    private static ByteString randomByteString(Integer payloadSize) {
-        byte[] ba = new byte[payloadSize];
-        for (int i = 0; i < payloadSize; i++) {
-            ba[i] = CHARACTERS[RANDOM().nextInt(CHARACTERS.length)];
-        }
+    private static ByteString randomByteString(Integer size) {
+        byte[] ba = new byte[size];
+        RANDOM().nextBytes(ba);
         return bs(ba);
     }
 
     private static ByteString bs(byte[] ba) {
         return ByteString.copyFrom(ba);
-    }
-
-    private static byte[] chars(Integer min, Integer max) {
-        byte[] ba = new byte[max - min + 1];
-        for (int i = min; i <= max; i++) {
-            ba[i - min] = (byte) i;
-        }
-        return ba;
     }
 }


### PR DESCRIPTION
(This PR is targeting #25)

Configure with `-sleep=INTERVAL`.

Clients wait `INTERVAL`ms (on average) before sending the next operation.
We do this by randomly partitioning `INTERVAL` into `#CLIENTS` buckets.
If `INTERVAL < #CLIENTS`, each client waits 1ms between each op.

`-sleep=42` gives close loop behaviour.